### PR TITLE
Hotfix erro no redirecionamento do carinho para pagamento

### DIFF
--- a/resources/js/api/checkout/cart.js
+++ b/resources/js/api/checkout/cart.js
@@ -308,7 +308,7 @@ $(document).on("click", "#finalizePurchase", function (e) {
         data: {},
         success: function (data) {
             if (data.success === true)
-                window.location.href = data.redirect
+                window.location.href = '/' + data.redirect
             else
                 _alert("Mensagem", data.message, "error")
         },


### PR DESCRIPTION
Esse commit corrige um redirecionamento errado que acontece quando um cliente já identificado passa do carrinho para o pagamento.

O erro é o redirecionamento para a url `/Checkout/checkout/Payment` que é uma pagina de erro. A url correta deve ser `/checkout/Payment`