### PR TITLE
Adicionar ID ao modal de login para prevenir conflito

### DIFF
--- a/Views/Customer/Accesskey.cshtml
+++ b/Views/Customer/Accesskey.cshtml
@@ -67,7 +67,7 @@
 </div>
 
 
-<div class="ui mini modal" data-modal="">
+<div class="ui mini modal" id="LoginModal" data-modal="">
     <i class="close icon"></i>
     <div class="content">
         <div class="ui form" id="formAccessKey">

--- a/Views/Customer/CheckAccessKey.cshtml
+++ b/Views/Customer/CheckAccessKey.cshtml
@@ -89,7 +89,7 @@
 </div>
 @section custom_js {
     <script>
-        var emailCustomer = '@Session["email"]';
+        var emailCustomer = '@Session["email"]'
 
         function gettoken() {
             var token = '@Html.AntiForgeryToken()';

--- a/Views/Customer/CheckAccessKey.cshtml
+++ b/Views/Customer/CheckAccessKey.cshtml
@@ -89,7 +89,7 @@
 </div>
 @section custom_js {
     <script>
-        var emailCustomer = '@Session["email"]'
+        var emailCustomer = '@Session["email"]';
 
         function gettoken() {
             var token = '@Html.AntiForgeryToken()';

--- a/resources/js/api/customer/AccessKey.js
+++ b/resources/js/api/customer/AccessKey.js
@@ -77,7 +77,7 @@ $(document).ready(function () {
             success: function (data) {
                 if (data.Success == true && data.Message == "Login") {
                     $("#UserName").val(strLogin);
-                    $('.ui.modal').modal('show');
+                    $('#LoginModal').modal('show');
                 } else if (data.Success == true && data.Message == "CadastrarSenha") {
                     window.location.href = "/Customer/CheckAccessKey?email=" + data.Email;
                 } else if (data.Success == true && data.Message == "Cadastro") {


### PR DESCRIPTION
Esse pull request visa solucionar um problema que ocorreu em uma loja que estou participando do desenvolvimento.

Ao tentar cadastrar um cliente com um E-mail ou CPF existente, é aberto um modal para login informando que aquele usuário já existe, mas atualmente a função é executada em todos os elementos com a classes ".ui.modal", caso a loja tenha outros modals na mesma página, no header, ou no footer, ele é aberto em conjunto, pra prevenir isso, eu vinculei um ID ao modal de login