### PR TITLE
Adiciona ";" faltando

### DIFF
--- a/Views/Customer/CheckAccessKey.cshtml
+++ b/Views/Customer/CheckAccessKey.cshtml
@@ -89,7 +89,7 @@
 </div>
 @section custom_js {
     <script>
-        var emailCustomer = '@Session["email"]'
+        var emailCustomer = '@Session["email"]';
 
         function gettoken() {
             var token = '@Html.AntiForgeryToken()';


### PR DESCRIPTION
A falta do `;` ocasionava erros como não identificar a existência da função `gettoken` e o retorno da variável `emailCustomer` ser nulo